### PR TITLE
added node and relationship to recycle id

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/configuration/CommunityIdTypeConfigurationProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/configuration/CommunityIdTypeConfigurationProvider.java
@@ -37,8 +37,8 @@ public class CommunityIdTypeConfigurationProvider implements IdTypeConfiguration
 {
 
     private static final Set<IdType> TYPES_TO_ALLOW_REUSE =
-            Collections.unmodifiableSet( EnumSet.of( IdType.PROPERTY, IdType.STRING_BLOCK,
-                    IdType.ARRAY_BLOCK, IdType.NODE_LABELS ) );
+            Collections.unmodifiableSet( EnumSet.of( IdType.NODE, IdType.RELATIONSHIP, IdType.PROPERTY,
+                        IdType.STRING_BLOCK, IdType.ARRAY_BLOCK, IdType.NODE_LABELS ) );
 
     private final Map<IdType,IdTypeConfiguration> typeConfigurations = new EnumMap<>( IdType.class );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/configuration/CommunityIdTypeConfigurationProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/configuration/CommunityIdTypeConfigurationProviderTest.java
@@ -41,7 +41,7 @@ public class CommunityIdTypeConfigurationProviderTest
     @Parameterized.Parameters
     public static List<IdType> data()
     {
-        return Arrays.asList(IdType.PROPERTY, IdType.STRING_BLOCK, IdType.ARRAY_BLOCK, IdType.NODE_LABELS );
+        return Arrays.asList( IdType.NODE, IdType.RELATIONSHIP, IdType.PROPERTY, IdType.STRING_BLOCK, IdType.ARRAY_BLOCK, IdType.NODE_LABELS );
     }
 
     public CommunityIdTypeConfigurationProviderTest( IdType reusableType )
@@ -53,9 +53,9 @@ public class CommunityIdTypeConfigurationProviderTest
     public void nonReusableTypeConfiguration()
     {
         IdTypeConfigurationProvider provider = createIdTypeProvider();
-        IdTypeConfiguration typeConfiguration = provider.getIdTypeConfiguration( IdType.RELATIONSHIP );
-        assertFalse( "Relationship ids are not reusable.", typeConfiguration.allowAggressiveReuse() );
-        assertEquals( "Relationship ids are not reusable.", IdTypeConfiguration.DEFAULT_GRAB_SIZE, typeConfiguration.getGrabSize() );
+        IdTypeConfiguration typeConfiguration = provider.getIdTypeConfiguration( IdType.SCHEMA );
+        assertFalse( "Schema ids are not reusable.", typeConfiguration.allowAggressiveReuse() );
+        assertEquals( "Schema ids are not reusable.", IdTypeConfiguration.DEFAULT_GRAB_SIZE, typeConfiguration.getGrabSize() );
     }
 
     @Test


### PR DESCRIPTION
well Currently node and relationship aren't part of recycle id without restarting Db, this improvement to recycle id without Db restart 